### PR TITLE
大佬，发现您的项目引入了commons-io:commons-io@2.6组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -52,7 +50,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Apache Commons IO路径遍历漏洞
缺陷组件：commons-io:commons-io@2.6
漏洞编号：CVE-2021-29425
漏洞描述：Apache Commons IO是美国阿帕奇基金会（Apache）公司的一个应用程序。可以帮助开发IO功能。
Apache Commons IO 2.2版本至2.6版本存在路径遍历漏洞。该漏洞与FileNameUtils.normalize方法有关。攻击者可以利用该漏洞通过发送错误的输入字符串（例如“//../foo”或“\\..\foo”）获得对父目录中文件的访问权限。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2021-30583
影响范围：[0, 2.7)
最小修复版本：2.7
缺陷组件引入路径：com.demo:elk@1.0-SNAPSHOT->commons-io:commons-io@2.6
```
另外我运行这个项目时，IDE的安全插件提示还有168个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p0b70b